### PR TITLE
Add tooltips to display word form from the context pack page

### DIFF
--- a/client/src/app/wordlists/wordlist-card/wordlist-card.component.html
+++ b/client/src/app/wordlists/wordlist-card/wordlist-card.component.html
@@ -13,23 +13,31 @@
         <div class="nounsList" *ngIf="wordlist.nouns.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="nouns">Nouns:</p>
-            <p color="primary" class="bubble noun" matTooltip="{{noun.forms}}" matTooltipPosition="above" *ngFor="let noun of wordlist.nouns">{{noun.word}}</p>
+            <p color="primary" class="bubble noun" matTooltip="{{noun.forms}}" matTooltipPosition="above" matTooltipClass="context-pack-words" *ngFor="let noun of wordlist.nouns">
+              {{noun.word}}
+            </p>
           </div>
           <div class="verbsList" *ngIf="wordlist.verbs.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="verbs">Verbs:</p>
-            <p color="primary" class="bubble verb" matTooltip="{{verb.forms}}" matTooltipPosition="above" *ngFor="let verb of wordlist.verbs">{{verb.word}}</p>
+            <p color="primary" class="bubble verb" matTooltip="{{verb.forms}}" matTooltipPosition="above" matTooltipClass="context-pack-words" *ngFor="let verb of wordlist.verbs">
+              {{verb.word}}
+            </p>
           </div>
           <div class="adjectivesList" *ngIf="wordlist.adjectives.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="adjectives">Adjectives:</p>
-            <p color="primary" class="bubble adjective" matTooltip="{{ad.forms}}" matTooltipPosition="above" *ngFor="let ad of wordlist.adjectives">{{ad.word}}</p>
+            <p color="primary" class="bubble adjective" matTooltip="{{ad.forms}}" matTooltipPosition="above" matTooltipClass="context-pack-words" *ngFor="let ad of wordlist.adjectives">
+              {{ad.word}}
+            </p>
 
           </div>
           <div class="miscList" *ngIf="wordlist.misc.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="misc">Misc:</p>
-            <p color="primary" class="bubble misc" matTooltip="{{m.forms}}" matTooltipPosition="above" *ngFor="let m of wordlist.misc">{{m.word}}</p>
+            <p color="primary" class="bubble misc" matTooltip="{{m.forms}}" matTooltipPosition="above" matTooltipClass="context-pack-words" *ngFor="let m of wordlist.misc">
+              {{m.word}}
+            </p>
 
           </div>
     </div>

--- a/client/src/app/wordlists/wordlist-card/wordlist-card.component.html
+++ b/client/src/app/wordlists/wordlist-card/wordlist-card.component.html
@@ -13,23 +13,23 @@
         <div class="nounsList" *ngIf="wordlist.nouns.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="nouns">Nouns:</p>
-            <p color="primary" class="bubble noun" *ngFor="let noun of wordlist.nouns">{{noun.word}}</p>
+            <p color="primary" class="bubble noun" matTooltip="{{noun.forms}}" matTooltipPosition="above" *ngFor="let noun of wordlist.nouns">{{noun.word}}</p>
           </div>
           <div class="verbsList" *ngIf="wordlist.verbs.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="verbs">Verbs:</p>
-            <p color="primary" class="bubble verb" *ngFor="let verb of wordlist.verbs">{{verb.word}}</p>
+            <p color="primary" class="bubble verb" matTooltip="{{verb.forms}}" matTooltipPosition="above" *ngFor="let verb of wordlist.verbs">{{verb.word}}</p>
           </div>
           <div class="adjectivesList" *ngIf="wordlist.adjectives.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="adjectives">Adjectives:</p>
-            <p color="primary" class="bubble adjective" *ngFor="let ad of wordlist.adjectives">{{ad.word}}</p>
+            <p color="primary" class="bubble adjective" matTooltip="{{ad.forms}}" matTooltipPosition="above" *ngFor="let ad of wordlist.adjectives">{{ad.word}}</p>
 
           </div>
           <div class="miscList" *ngIf="wordlist.misc.length > 0">
             <!--display:flex-->
             <p  class="desc title-section" element="misc">Misc:</p>
-            <p color="primary" class="bubble misc" *ngFor="let m of wordlist.misc">{{m.word}}</p>
+            <p color="primary" class="bubble misc" matTooltip="{{m.forms}}" matTooltipPosition="above" *ngFor="let m of wordlist.misc">{{m.word}}</p>
 
           </div>
     </div>

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -98,6 +98,10 @@ body {
   text-transform: uppercase;
 }
 
+.mat-tooltip.context-pack-words {
+  font-size: 14px;
+}
+
 // Special styling for the E2E test highlighter
 #BP_ELEMENT_HIGHLIGHT__ {
   z-index: 100;


### PR DESCRIPTION
Hovering over words now displays their forms in a tooltip.